### PR TITLE
Misc: 5.2 Update

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,12 +37,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        django: ["32", "40", "41", "42", "main"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django: ["42", "50", "52", "main"]
         exclude:
+          - python: "3.8"
+            django: "50"
+          - python: "3.8"
+            django: "52"
           - python: "3.8"
             django: "main"
           - python: "3.9"
+            django: "50"
+          - python: "3.9"
+            django: "52"
+          - python: "3.9"
+            django: "main"
+          - python: "3.10"
+            django: "main"
+          - python: "3.11"
             django: "main"
 
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,21 @@
 repos:
   # python code formatting - will amend files
   - repo: https://github.com/ambv/black
-    rev: 23.9.1
+    rev: 24.1.1
     hooks:
       - id: black
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.292"
+    rev: "v0.1.13"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         args:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Django app for managing failed logins and account lockout.
 
+## Compatibility
+
+This package supports:
+- Django 4.2, 5.0, and 5.2
+- Python 3.8, 3.9, 3.10, 3.11, and 3.12
+
 ## Background
 
 Email / password logins (without MFA) are vulnerable to Brute Force attacks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-account-locker"
-version = "0.1.0"
+version = "0.2.0"
 description = "Django app to manage account login throttling."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,11 +13,9 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -31,7 +29,7 @@ packages = [{ include = "account_locker" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    py38-django{32,40,41,42}
-    py39-django{32,40,41,42}
-    py310-django{32,40,41,42,50,main}
-    py311-django{32,40,41,42,50,main}
-    py312-django{40,41,42,50,main}
+    py38-django42
+    py39-django42
+    py310-django{42,50,52}
+    py311-django{42,50,52,main}
+    py312-django{42,50,52,main}
 
 [testenv]
 deps =
@@ -15,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -46,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff account_locker
+    ruff check account_locker
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Update for Django 5.2 Support
This PR updates the django-account-locker package to add support for Django 5.2 while improving project configuration.

## Changes:
Updated Django version support:

1. Added support for Django 5.2
2. Deprecated support for Django versions prior to 4.2
3. Updated dependency requirements in pyproject.toml
4. Updated tox configuration to test against Django 4.2, 5.0, 5.2 and main
5. Updated GitHub Actions workflow to ensure Django main is only tested on Python 3.12
6. Updated pre-commit hooks to use latest versions
7. Updated ruff configuration to use modern ruff check syntax
8. Modified .ruff.toml to use the new sectioned format with [lint] section
9. Added ruff-format pre-commit hook for additional formatting capabilities

## Documentation:

1. Added compatibility section to README
2. Updated classifiers in pyproject.toml