### PR TITLE
 Add Django 6.0 and Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -37,25 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.8"
-            django: "50"
-          - python: "3.8"
-            django: "52"
-          - python: "3.8"
-            django: "main"
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
-            django: "52"
-          - python: "3.9"
-            django: "main"
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Django app for managing failed logins and account lockout.
 ## Compatibility
 
 This package supports:
-- Django 4.2, 5.0, and 5.2
-- Python 3.8, 3.9, 3.10, 3.11, and 3.12
+- Python 3.12+ and Django 5.2-6.0
 
 ## Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-account-locker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Django app to manage account login throttling."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,25 +13,21 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "account_locker" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^4.2 || ^5.0"
+python = "^3.12"
+django = ">=5.2,<7.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "*"
 coverage = "*"
 freezegun = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    py38-django42
-    py39-django42
-    py310-django{42,50,52}
-    py311-django{42,50,52,main}
-    py312-django{42,50,52,main}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -15,9 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)